### PR TITLE
fix: build errors since lack of dependency `texinfo`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+stow (2.4.1-2deepin1) unstable; urgency=medium
+
+  * Add dependency texinfo to avoid build errors
+
+ -- sisungo <sisungo@icloud.com>  Sat, 8 Nov 2025 15:58:12 +0800
+
 stow (2.4.1-2) unstable; urgency=medium
 
   * Removes #-escaping in Makefile.am (Closes: #1095395)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: stow
 Section: admin
 Priority: optional
 Maintainer: Chuan-kai Lin <cklin@debian.org>
-Build-Depends: debhelper-compat (= 13)
+Build-Depends: debhelper-compat (= 13), texinfo
 Build-Depends-Indep: quilt, perl, libio-stringy-perl, libtest-output-perl
 Rules-Requires-Root: no
 Standards-Version: 4.7.0


### PR DESCRIPTION
Errors while building on `riscv64` minimum tarball:

```
/root/stow/automake/missing: line 85: makeinfo: command not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <https://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <https://www.gnu.org/software/make/>
make[1]: *** [Makefile:1663: doc/manual-split] Error 1
make[1]: Leaving directory '/root/stow'
dh_auto_build: error: make -j8 returned exit code 2
```